### PR TITLE
Feat: Add Keycloak as Identity provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Guacamole provisioning
 
-This repository provides Terraform files to launch a Virtual Machine and deploy a Guacamole instance on it.
+This repository provides a Docker Compose setup for deploying Guacamole on OpenStack using Terraform. The setup includes integration with Keycloak for authentication.
 
 ## Requirements
 
-- A SSH Public key imported on Openstack. 
+- A SSH Public key imported on Openstack.
 - The credential of your OpenStack cluster in a `clouds.yaml` file.
 - Complete the `var.tf` file with the needed information
 
@@ -13,16 +13,43 @@ This repository provides Terraform files to launch a Virtual Machine and deploy 
 ```bash
 cd ./terraform
 terraform init
-terraform plan -out tfplan
+terraform plan -out tfplan --var keycloak_hostname=$KC_HOSTNAME --var guacamole_hostname=$GUACAMOLE_HOSTNAME 
 terraform apply -auto-approve tfplan
 ```
 
-## Access the Guacamole instance
+> [!IMPORTANT]
+> Replace `$KC_HOSTNAME` and `$GUACAMOLE_HOSTNAME` with the hostname you want to use for Keycloak and Guacamole respectively.
 
-Once deployed, the IP of the machine is displayed. You can then open your browser and go to http://$IP:8080/guacamole.
+## Creating a User in Keycloak
 
-## Delete
+1. After deploying the Docker Compose stack, retrieve the passwords created by running the following command:
 
-```bash
-terraform destroy -auto-approve
-```
+    ```bash
+    ssh debian@$IP_ADDRESS "cat ~/compose-guacamole-keycloak/.env"
+    ```
+
+    > [!NOTE]
+    > The IP address of the instance can be found in the Terraform output.
+
+2. Access the KEYCLOAK service at `https://KC_HOSTNAME` and connect with the admin user and the `KEYCLOAK_ADMIN_PASSWORD` password retrieved in the previous step.
+
+3. After logging, create a new realm and name it `guacamole`. Then, navigate to the "Users" section. Click "Add User" and provide the necessary details for the new user. Assign the user a password and remember the credentials for later access to Guacamole.
+
+## Adding a VM to Connect
+
+1. Go to `https://GUACAMOLE_HOSTNAME` and log in with the user created in the previous step.
+
+1. In the Guacamole interface, navigate to the "Settings" section.
+
+1. Click on the "Connections" tab.
+
+1. Click "New Connection" and provide the necessary details, including the connection name, protocol, and the address of the VM you want to connect to.
+
+1. Save the connection, and you should now be able to connect to the added VM through Guacamole.
+
+> [!NOTE]
+> Please note that additional configuration may be required based on your OpenStack setup and network configurations.
+
+## Author
+
+Written by [GridexX](https://github.com/GridexX) during February 2024. 

--- a/terraform/docker-compose.yml
+++ b/terraform/docker-compose.yml
@@ -1,0 +1,124 @@
+version: "3.7"
+services:
+  caddy:
+    image: lucaslorentz/caddy-docker-proxy:ci-alpine
+    ports:
+      - 80:80
+      - 443:443
+    environment:
+      - CADDY_INGRESS_NETWORKS=caddy
+    networks:
+      - caddy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - caddy_data:/data
+    restart: unless-stopped
+
+  keycloak:
+    container_name: keycloak
+    image: quay.io/keycloak/keycloak:latest
+    restart: unless-stopped
+    environment:
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://keycloak-db:5432/keycloak
+      KC_DB_USER: keycloak
+      KC_DB_SCHEMA: public
+      KC_DB_PASSWORD: ${KC_DB_PASSWORD}
+      KC_HOSTNAME: ${KC_HOSTNAME}
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
+      KC_PROXY: edge
+    # ports:
+    # - 8080:8080
+    depends_on:
+      - keycloak-db
+    networks:
+      - keycloak-nw
+      - caddy
+    command: start
+    labels:
+      caddy: ${KC_HOSTNAME}
+      caddy.reverse_proxy: "{{upstreams 8080}}"
+
+  keycloak-db:
+    container_name: keycloak-db
+    image: postgres:latest
+    restart: unless-stopped
+    security_opt:
+      - label:disable
+    volumes:
+      - keycloack-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: keycloak
+      POSTGRES_USER: keycloak
+      POSTGRES_PASSWORD: ${KC_DB_PASSWORD}
+    #   ports:
+    # - 5432:5432
+    networks:
+      - keycloak-nw
+
+  guacamole:
+    image: guacamole/guacamole:latest
+    container_name: guacamole
+    volumes:
+      - ./guacamole-data:/etc/guacamole
+    environment:
+      - GUACD_HOSTNAME=guacamole-guacd
+      - GUACAMOLE_HOME=/etc/guacamole
+      - POSTGRES_HOSTNAME=guacamole-db
+      - POSTGRES_DATABASE=guacamole_db
+      - POSTGRES_USER=guacamole
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - OPENID_AUTHORIZATION_ENDPOINT=https://${KC_HOSTNAME}/realms/master/protocol/openid-connect/auth
+      - OPENID_JWKS_ENDPOINT=https://${KC_HOSTNAME}/realms/master/protocol/openid-connect/certs
+      - OPENID_ISSUER=https://${KC_HOSTNAME}/realms/master
+      - OPENID_CLIENT_ID=guacamole
+      - OPENID_REDIRECT_URI=https://${GUACAMOLE_HOSTNAME}/guacamole
+
+    # ports:
+    #   - 8080:8080
+    restart: unless-stopped
+    labels:
+      caddy: ${GUACAMOLE_HOSTNAME}
+      caddy.reverse_proxy: "{{upstreams 8080}}"
+      caddy.reverse_proxy.flush_interval: "-1"
+    networks:
+      - caddy
+      - guacamole-nw
+
+  guacamole-guacd:
+    image: guacamole/guacd:latest
+    container_name: guacamole-guacd
+    security_opt:
+      - label:disable
+    networks:
+      - guacamole-nw
+    restart: unless-stopped
+
+  guacamole-db:
+    image: postgres:13
+    container_name: guacamole-db
+    security_opt:
+      - label:disable
+    restart: unless-stopped
+    environment:
+      - POSTGRES_DB=guacamole_db
+      - POSTGRES_USER=guacamole
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./guacamole-init:/docker-entrypoint-initdb.d # can be removed after initialization
+    networks:
+      - guacamole-nw
+
+
+networks:
+  keycloak-nw:
+  guacamole-nw:
+  caddy:
+    external: true
+
+volumes:
+  caddy_data: {}
+  keycloack-data: {}
+  postgres-data: {}

--- a/terraform/instance-init.sh
+++ b/terraform/instance-init.sh
@@ -39,6 +39,7 @@ sudo ln -s /etc/guacamole/guacamole.war /var/lib/tomcat9/webapps/
 echo "✅ Links created"
 
 echo "✅ Folders created"
+export GUACAMOLE_HOME=/etc/guacamole
 sudo su -c "echo 'GUACAMOLE_HOME=/etc/guacamole' >> /etc/default/tomcat9"
 sudo su -c "printf 'guacd-hostname: 127.0.0.1\nguacd-port: 4822\nuser-mapping:   /etc/guacamole/user-mapping.xml\nauth-provider:  net.sourceforge.guacamole.net.basic.BasicFileAuthenticationProvider\n' >> /etc/guacamole/guacamole.properties"
 sudo ln -s /etc/guacamole /usr/share/tomcat9/.guacamole
@@ -49,3 +50,13 @@ curl -LO https://gist.githubusercontent.com/GridexX/ee38770e619a3b41bb0de132666b
 sudo mv /tmp/user-mapping.xml /etc/guacamole
 sudo systemctl restart tomcat9 guacd
 # TODO: Check how to retrieve user from the Edugain Federation
+
+# This section will be usefull for the SSO plugin with Edugain Federation
+# Install the SSO Plugin for Guacamole
+# curl -LO https://apache.org/dyn/closer.lua/guacamole/$GUACAMOLE_VERSION/binary/guacamole-auth-sso-$GUACAMOLE_VERSION.tar.gz?action=download
+# tar -xzf guacamole-auth-sso-$GUACAMOLE_VERSION.tar.gz
+# sudo mv guacamole-auth-sso-$GUACAMOLE_VERSION/saml/guacamole-auth-sso-saml-$GUACAMOLE_VERSION.jar $GUACAMOLE_HOME/extensions
+# # Configuring the plugin
+# sudo -c "printf 'saml-idp-metadata-url:\n' >> $GUACAMOLE_HOME/guacamole.properties"
+
+# Install

--- a/terraform/keycloak-init.tftpl
+++ b/terraform/keycloak-init.tftpl
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Fist parameter is the Keycloak URL
+# Second parameter is the Guacamole URL
+export KC_HOSTNAME=${keycloak_hostname}
+export GUACAMOLE_HOSTNAME=${guacamole_hostname}
+
+
+# --- Install Docker
+
+# Add Docker's official GPG key:
+sudo apt-get update -y
+sudo apt-get install -y ca-certificates curl
+sudo install -y -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update -y
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo systemctl enable docker.service
+sudo systemctl enable containerd.service
+usermod -aG docker $USER
+newgrp docker
+
+# --- Setup the project
+# Create a network for the containers
+docker network create caddy
+
+# Init the DB for guacamole
+mkdir -p ~/compose-guacamole-keycloak/guacamole-init
+docker run --rm guacamole/guacamole /opt/guacamole/bin/initdb.sh --postgresql > guacamole-init/initdb.sql
+
+# Install the SSO Plugin for Guacamole
+GUACAMOLE_VERSION="1.5.4"
+cd /tmp
+curl -LO https://apache.org/dyn/closer.lua/guacamole/$GUACAMOLE_VERSION/binary/guacamole-auth-sso-$GUACAMOLE_VERSION.tar.gz?action=download
+tar -xzf guacamole-auth-sso-$GUACAMOLE_VERSION.tar.gz
+mkdir ~/compose-guacamole-keycloak/guacamole-data/extensions/
+mv guacamole-auth-sso-$GUACAMOLE_VERSION/openid/guacamole-auth-sso-openid-$GUACAMOLE_VERSION.jar ~/compose-guacamole-keycloak/guacamole-data/extensions/extensions
+
+# Create random passwords
+# export GUACAMOLE_PASSWORD=$(openssl rand -base64 12)
+cd ~/compose-guacamole-keycloak
+export KC_DB_PASSWORD=$(openssl rand -hex 32)
+export KEYCLOAK_ADMIN_PASSWORD=$(openssl rand -hex 32)
+export POSTGRES_PASSWORD=$(openssl rand -hex 32) #Password used for the Guacamole DB
+# Write the password to a file so we can use it later
+echo "KC_DB_PASSWORD: $KC_DB_PASSWORD" > ~/.passwords
+echo "KEYCLOAK_ADMIN_PASSWORD: $KEYCLOAK_ADMIN_PASSWORD" >> ~/.passwords
+echo "POSTGRES_PASSWORD: $POSTGRES_PASSWORD" >> ~/.passwords
+
+# Download the Docker Compose file and start the containers
+curl -LO https://gist.githubusercontent.com/GridexX/8eabac30c4875e6ed36e37ab45798ddc/raw/0776a82caef2ca84c192f1e25725f43b0f40e430/docker-compose.yml
+docker compose up -d

--- a/terraform/keycloak-init.tftpl
+++ b/terraform/keycloak-init.tftpl
@@ -24,24 +24,25 @@ sudo apt-get update -y
 sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 sudo systemctl enable docker.service
 sudo systemctl enable containerd.service
-usermod -aG docker $USER
-newgrp docker
+sudo usermod -aG docker $USER
 
+echo "[#----] ✅ Docker installed"
 # --- Setup the project
 # Create a network for the containers
-docker network create caddy
+sudo docker network create caddy
 
 # Init the DB for guacamole
 mkdir -p ~/compose-guacamole-keycloak/guacamole-init
-docker run --rm guacamole/guacamole /opt/guacamole/bin/initdb.sh --postgresql > guacamole-init/initdb.sql
-
+sudo docker run --rm guacamole/guacamole /opt/guacamole/bin/initdb.sh --postgresql > ~/compose-guacamole-keycloak/guacamole-init/initdb.sql
+echo "[##---] ✅ DB initialized"
 # Install the SSO Plugin for Guacamole
 GUACAMOLE_VERSION="1.5.4"
 cd /tmp
 curl -LO https://apache.org/dyn/closer.lua/guacamole/$GUACAMOLE_VERSION/binary/guacamole-auth-sso-$GUACAMOLE_VERSION.tar.gz?action=download
 tar -xzf guacamole-auth-sso-$GUACAMOLE_VERSION.tar.gz
-mkdir ~/compose-guacamole-keycloak/guacamole-data/extensions/
-mv guacamole-auth-sso-$GUACAMOLE_VERSION/openid/guacamole-auth-sso-openid-$GUACAMOLE_VERSION.jar ~/compose-guacamole-keycloak/guacamole-data/extensions/extensions
+mkdir -p ~/compose-guacamole-keycloak/guacamole-data/extensions/
+mv guacamole-auth-sso-$GUACAMOLE_VERSION/openid/guacamole-auth-sso-openid-$GUACAMOLE_VERSION.jar ~/compose-guacamole-keycloak/guacamole-data/extensions/
+echo "[###--] ✅ Guacamole sso plugin installed"
 
 # Create random passwords
 # export GUACAMOLE_PASSWORD=$(openssl rand -base64 12)
@@ -50,10 +51,16 @@ export KC_DB_PASSWORD=$(openssl rand -hex 32)
 export KEYCLOAK_ADMIN_PASSWORD=$(openssl rand -hex 32)
 export POSTGRES_PASSWORD=$(openssl rand -hex 32) #Password used for the Guacamole DB
 # Write the password to a file so we can use it later
-echo "KC_DB_PASSWORD: $KC_DB_PASSWORD" > ~/.passwords
-echo "KEYCLOAK_ADMIN_PASSWORD: $KEYCLOAK_ADMIN_PASSWORD" >> ~/.passwords
-echo "POSTGRES_PASSWORD: $POSTGRES_PASSWORD" >> ~/.passwords
+echo "KC_DB_PASSWORD='$KC_DB_PASSWORD'" > ~/compose-guacamole-keycloak/.env
+echo "KEYCLOAK_ADMIN_PASSWORD: $KEYCLOAK_ADMIN_PASSWORD" >> ~/compose-guacamole-keycloak/.env
+echo "POSTGRES_PASSWORD: $POSTGRES_PASSWORD" >> ~/compose-guacamole-keycloak/.env
+echo " [####-] ✅ Passwords generated"
 
 # Download the Docker Compose file and start the containers
+cd /tmp
 curl -LO https://gist.githubusercontent.com/GridexX/8eabac30c4875e6ed36e37ab45798ddc/raw/0776a82caef2ca84c192f1e25725f43b0f40e430/docker-compose.yml
-docker compose up -d
+envsubst < docker-compose.yml > ~/compose-guacamole-keycloak/docker-compose.yml
+cd ~/compose-guacamole-keycloak
+sudo docker compose up -d
+echo "[#####] ✅ Containers started and running"
+exit 0

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,6 +9,30 @@ resource "openstack_compute_instance_v2" "instance" {
   network {
     uuid = openstack_networking_network_v2.private_net.id
   }
+
+  connection {
+    type = "ssh"
+    user = "debian"
+    host = openstack_networking_floatingip_v2.floating_ip.address
+  }
+
+  provisioner "file" {
+    destination      = "/tmp/keycloak-init.sh"
+    content = templatefile(
+      "${path.module}/keycloak-init.tftpl",
+      { 
+        "kc_hostname": var.keycloak_hostname,
+        "guacamole_hostname" : var.guacamole_hostname,
+      }
+    )
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /tmp/keycloak-init.sh",
+      "/tmp/keycloak-init.sh",
+    ]
+  }
 }
 
 resource "openstack_networking_floatingip_v2" "floating_ip" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,27 +4,31 @@ resource "openstack_compute_instance_v2" "instance" {
   flavor_name     = var.flavor_name
   key_pair        = var.ssh_key_name
   security_groups = var.security_groups
-  user_data = file("./instance-init.sh")
 
   network {
     uuid = openstack_networking_network_v2.private_net.id
   }
 
-  connection {
-    type = "ssh"
-    user = "debian"
-    host = openstack_networking_floatingip_v2.floating_ip.address
-  }
+}
 
+resource "null_resource" "remote_exec_instance" {
+
+  depends_on = [openstack_compute_floatingip_associate_v2.floating_ip_association]
   provisioner "file" {
-    destination      = "/tmp/keycloak-init.sh"
+    destination = "/tmp/keycloak-init.sh"
     content = templatefile(
       "${path.module}/keycloak-init.tftpl",
-      { 
-        "kc_hostname": var.keycloak_hostname,
+      {
+        "keycloak_hostname" : var.keycloak_hostname,
         "guacamole_hostname" : var.guacamole_hostname,
       }
     )
+  }
+  connection {
+    type        = "ssh"
+    user        = "debian"
+    host        = openstack_networking_floatingip_v2.floating_ip.address
+    private_key = file("~/.ssh/id_rsa")
   }
 
   provisioner "remote-exec" {
@@ -48,3 +52,5 @@ resource "openstack_compute_floatingip_associate_v2" "floating_ip_association" {
 output "instance_fip_address" {
   value = openstack_networking_floatingip_v2.floating_ip.address
 }
+
+

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,10 +1,10 @@
 terraform {
-    required_version = ">= 0.14.0"
-    
-    required_providers {
-        openstack = {
-            source  = "terraform-provider-openstack/openstack"
-            version = "~> 1.53.0"
-        }
+  required_version = ">= 0.14.0"
+
+  required_providers {
+    openstack = {
+      source  = "terraform-provider-openstack/openstack"
+      version = "~> 1.53.0"
     }
+  }
 }

--- a/terraform/var.tf
+++ b/terraform/var.tf
@@ -19,3 +19,13 @@ variable "security_groups" {
 variable "public_network_name" {
   default = "public2"
 }
+
+variable "keycloak_hostname" {
+  type = string
+  description= "Keycloak hostname, e.g. keycloak.example.com"
+}
+
+variable "guacamole_hostname" {
+  type= string
+  description= "Guacamole hostname, e.g. guacamole.example.com"
+}

--- a/terraform/var.tf
+++ b/terraform/var.tf
@@ -9,7 +9,7 @@ variable "flavor_name" {
 }
 
 variable "ssh_key_name" {
-  default = "gridexx-latitude5420" 
+  default = "gridexx-latitude5420"
 }
 
 variable "security_groups" {
@@ -21,11 +21,11 @@ variable "public_network_name" {
 }
 
 variable "keycloak_hostname" {
-  type = string
-  description= "Keycloak hostname, e.g. keycloak.example.com"
+  type        = string
+  description = "Keycloak hostname, e.g. keycloak.example.com"
 }
 
 variable "guacamole_hostname" {
-  type= string
-  description= "Guacamole hostname, e.g. guacamole.example.com"
+  type        = string
+  description = "Guacamole hostname, e.g. guacamole.example.com"
 }


### PR DESCRIPTION
This PR introduces a new feature.

It provides an instances with a Keycloak instance.
Services are now launched from Docker within a `docker-compose.yaml` file. 

SSL Certificates are obtain thanks to Caddy and could be put inside Terraform variables